### PR TITLE
Fix #3: Large number of devices can cause homebridge-ikea to not start or work.

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,4 +1,4 @@
-var exec = require('child_process').exec
+var execSync = require('child_process').execSync
 
 const coap = (method, config) => `coap-client -u "Client_identity" -k "${config.psk}" -m ${method} coaps://${config.ip}/15001/`
 
@@ -22,12 +22,7 @@ module.exports.setBrightness = (config, id, brightness, callback) => {
     config.log(cmd)
   }
 
-  exec(cmd, function(error, stdout, stderr) {
-    if (config.debug) {
-      config.log(stdout)
-    }
-    callback(stdout)
-  })
+  callback(execSync(cmd, {encoding: "utf8"}))
 }
 
 module.exports.setKelvin = (config, id, kelvin, callback) => {
@@ -36,12 +31,7 @@ module.exports.setKelvin = (config, id, kelvin, callback) => {
   if (config.debug) {
     config.log(cmd)
   }
-  exec(cmd, function(error, stdout, stderr) {
-    if (config.debug) {
-      config.log(stdout)
-    }
-    callback(stdout)
-  })
+  callback(execSync(cmd, {encoding: "utf8"}))
 }
 
 // @TODO: Figure out if the gateway actually don't support this
@@ -50,12 +40,7 @@ module.exports.setOnOff = (config, id, state, callback) => {
   if (config.debug) {
     config.log(cmd)
   }
-  exec(cmd, function(error, stdout, stderr) {
-    if (config.debug) {
-      config.log(stdout)
-    }
-    callback(stdout)
-  })
+  callback(execSync(cmd, {encoding: "utf8"}))
 }
 
 const parseDeviceList = str => {
@@ -69,9 +54,7 @@ module.exports.getDevices = config => new Promise((resolve, reject) => {
     config.log(cmd)
   }
 
-  exec(cmd, function(error, stdout, stderr) {
-    resolve(parseDeviceList(stdout))
-  })
+  resolve(parseDeviceList(execSync(cmd, {encoding: "utf8"})))
 })
 
 const parseDevice = str => {
@@ -116,7 +99,6 @@ module.exports.getDevice = (config, id) => new Promise((resolve, reject) => {
     config.log(cmd)
   }
 
-  exec(cmd, function(error, stdout, stderr) {
-    resolve(parseDevice(stdout))
-  })
+  resolve(parseDevice(execSync(cmd, {encoding: "utf8"})))
+
 })


### PR DESCRIPTION
This PR is based on top of #2 , but only 39b3fe58aae9b223ad116fc73659316700760d8c is important here.

As noted on #3, when having a large number of devices (+10), the IKEA Gateway can't handle that. This may cause start up issues, or operational crashes.

This PR modifies all calls to the `coap-client` to be synchronous, although it could be possible to create a shared pool of tasks that allow async calls but less than 10 at any time.

It has been also observed that `coap-client` will not return even when setting a timeout, when this error happens.