### PR TITLE
Adding a more fail safe handling of coap-client lookups.

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ IkeaPlatform.prototype = {
 
     await Promise.all(devices.map(async deviceId => {
       const device = await utils.getDevice(self.config, deviceId)
-      if (device.type === 2) {
+      if (device && device.type === 2) {
         foundAccessories.push(new IkeaAccessory(self.log, self.config, device))
       }
     }))
@@ -106,48 +106,90 @@ IkeaAccessory.prototype = {
     lightbulbService
     .getCharacteristic(Characteristic.StatusActive)
     .on('get', callback => {
-      utils.getDevice(self.config, self.device.instanceId).then(device => {
-        callback(null, device.reachabilityState)
-      })
+      try {
+        utils.getDevice(self.config, self.device.instanceId).then(device => {
+          if(!device) {
+            throw "Time out getDevice"
+          }
+          callback(null, device.reachabilityState)
+        })       
+      } catch (error) {
+        callback("no_response")
+      }
     })
 
     lightbulbService
     .getCharacteristic(Characteristic.On)
     .on('get', callback => {
-      utils.getDevice(self.config, self.device.instanceId).then(device => {
-        self.currentBrightness = device.light[0]["5851"]
-        self.currentState = device.light[0]["5850"]
-        callback(null, self.currentState)
-      })
+      try {
+        utils.getDevice(self.config, self.device.instanceId).then(device => {
+          if(!device) {
+            throw "Time out getDevice"
+          }
+          self.currentBrightness = device.light[0]["5851"]
+          self.currentState = device.light[0]["5850"]
+          callback(null, self.currentState)
+        })
+      } catch (error) {
+        if (self.config.debug) {
+          self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.On get) \n' + error.message)
+        }
+        callback("no_response")
+      }
     })
     .on('set', (state, callback) => {
       if (typeof state !== 'number') {
         state = state ? 1 : 0;
       }    
       
-      if (self.currentState == 1 && state == 0) { // We're turned on but want to turn off.
-        self.currentState = 0
-        utils.setBrightness(self.config, self.device.instanceId, 0, result => callback())
-      } else if(self.currentState == 0 && state == 1) {
-        self.currentState = 1
-        utils.setBrightness(self.config, self.device.instanceId, (self.currentBrightness > 1 ? self.currentBrightness : 255), result => callback())
-      } else {
-        callback()
+      try {        
+        if (self.currentState == 1 && state == 0) { // We're turned on but want to turn off.
+          self.currentState = 0
+          utils.setBrightness(self.config, self.device.instanceId, 0, result => callback())
+        } else if(self.currentState == 0 && state == 1) {
+          self.currentState = 1
+          utils.setBrightness(self.config, self.device.instanceId, (self.currentBrightness > 1 ? self.currentBrightness : 255), result => callback())
+        } else {
+          callback()
+        }
+      } catch (error) {
+        if (self.config.debug) {
+          self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.On set) \n' + error.message)
+        }
+        callback("no_response")
       }
+
     })
 
     lightbulbService
     .getCharacteristic(Characteristic.Brightness)
     .on('get', callback => {
-      utils.getDevice(self.config, self.device.instanceId).then(device => {
-        self.currentBrightness = device.light[0]["5851"]
-        self.currentState = device.light[0]["5850"]
-        callback(null, parseInt(Math.round(self.currentBrightness * 100 / 255)))
-      })
+      try {
+        utils.getDevice(self.config, self.device.instanceId).then(device => {
+          if(!device) {
+            throw "Time out getDevice"
+          }
+          self.currentBrightness = device.light[0]["5851"]
+          self.currentState = device.light[0]["5850"]
+          callback(null, parseInt(Math.round(self.currentBrightness * 100 / 255)))
+        })
+      } catch (error) {
+        if (self.config.debug) {
+          self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.Brightness) get \n' + error.message)
+        }
+        callback("no_response")
+      }
     })
     .on('set', (powerOn, callback) => {
       self.currentBrightness = Math.floor(255 * (powerOn / 100))
-      utils.setBrightness(self.config, self.device.instanceId, Math.round(255 * (powerOn / 100)), result => callback())
+      try {
+        utils.setBrightness(self.config, self.device.instanceId, Math.round(255 * (powerOn / 100)), result => callback())
+      } catch (error) {
+        if (self.config.debug) {
+          self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.Brightness) set \n' + error.message)
+        }
+        callback("no_response")
+      }
     })
             
     if(typeof this.device.light[0]["5706"] !== 'undefined'){
@@ -155,7 +197,15 @@ IkeaAccessory.prototype = {
             this.device.light[0]["5706"] = "ffcea6" //Default value when it was offline
         }
         
-        var hsl = utils.convertRGBToHSL(this.device.light[0]["5706"]);
+        var hsl;
+        try {
+          hsl = utils.convertRGBToHSL(this.device.light[0]["5706"])
+        } catch (error) {
+          hsl = utils.convertRGBToHSL("ffcea6"); //default value
+          if (self.config.debug) {          
+            self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.Brightness) set convertRGBToHSL'  + this.device.light[0]["5706"]+  '\n' + error.message)
+          }
+        }
         
         lightbulbService
         .addCharacteristic(Characteristic.Kelvin)
@@ -169,56 +219,131 @@ IkeaAccessory.prototype = {
         lightbulbService
         .getCharacteristic(Characteristic.Kelvin)
         .on('get', callback => {
-          utils.getDevice(self.config, self.device.instanceId).then(device => {
-            self.currentKelvin = utils.getKelvin(device.light[0]["5709"])
-            callback(null, self.currentKelvin)
-          })
+          try {            
+            utils.getDevice(self.config, self.device.instanceId).then(device => {
+              if(!device) {
+                throw "Time out getDevice"
+              }
+              self.currentKelvin = utils.getKelvin(device.light[0]["5709"])
+              callback(null, self.currentKelvin)
+            })
+          } catch (error) {
+            if (self.config.debug) {
+              self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.Kelvin) 5706 get \n' + error.message)
+            }
+            callback("no_response")
+          }
         })
         .on('set', (kelvin, callback) => {
-          utils.setKelvin(self.config, self.device.instanceId, kelvin, result => callback())
+          try {            
+            utils.setKelvin(self.config, self.device.instanceId, kelvin, result => callback())
+          } catch (error) {
+            if (self.config.debug) {
+              self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.Kelvin) 5706 set \n' + error.message)
+            }
+            callback("no_response")
+          }
         })
 
         lightbulbService
           .getCharacteristic(Characteristic.Hue)
           .on('get', callback => {
-            utils.getDevice(self.config, self.device.instanceId).then(device => {
-              if(typeof device.light[0]["5706"] !== 'undefined' || device.light[0]["5706"].length < 6){
-                device.light[0]["5706"] = "ffcea6" //Default value when it fails polling
+            try {
+              utils.getDevice(self.config, self.device.instanceId).then(device => {
+                if(!device) {
+                  throw "Time out getDevice"
+                }
+                if(typeof device.light[0]["5706"] === 'undefined' || device.light[0]["5706"] && device.light[0]["5706"].length < 6){
+                  if (self.config.debug) {
+                    self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.Hue) get failed polling Hue, return value \n' + device.light[0]["5706"])
+                  }
+                  device.light[0]["5706"] = "ffcea6" //Default value when it fails polling
+                }
+                var hsl;
+                try {
+                  hsl = utils.convertRGBToHSL(device.light[0]["5706"])
+                } catch (error) {
+                  hsl = utils.convertRGBToHSL("ffcea6"); //default value
+                  if (self.config.debug) {          
+                    self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.Hue) set convertRGBToHSL '  + device.light[0]["5706"]+  '\n' + error.message)
+                  }
+                }
+                
+                callback(null, hsl[0] * 360)
+              })
+            } catch (error) {
+              if (self.config.debug) {
+                self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.Hue) get \n' + error.message)
               }
-              var hsl = utils.convertRGBToHSL(device.light[0]["5706"]);
-              callback(null, hsl[0] * 360)
-            })
+              callback("no_response")
+            }
 
           })
           .on('set', (hue, callback) => {
             self.color.hue = hue / 360
-            if (typeof self.color.saturation !== 'undefined') {
-              utils.setColor(self.config, self.device.instanceId, self.color, result => callback())
-              self.color = {}
-            }else{
-              callback()            
+            try {              
+              if (typeof self.color.saturation !== 'undefined') {
+                utils.setColor(self.config, self.device.instanceId, self.color, result => callback())
+                self.color = {}
+              }else{
+                callback()            
+              }
+            } catch (error) {
+              if (self.config.debug) {
+                self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.Hue) set \n' + error.message)
+              }
+              callback("no_response")
             }
           })
 
         lightbulbService
           .getCharacteristic(Characteristic.Saturation)
           .on('get', callback => {
-            utils.getDevice(self.config, self.device.instanceId).then(device => {
-              if(typeof device.light[0]["5706"] !== 'undefined' || device.light[0]["5706"].length < 6){
-                device.light[0]["5706"] = "ffcea6" //Default value when it fails polling
+            try {
+              utils.getDevice(self.config, self.device.instanceId).then(device => {
+                if(!device) {
+                  throw "Time out getDevice"
+                }
+                if(typeof device.light[0]["5706"] === 'undefined' || device.light[0]["5706"] && device.light[0]["5706"].length < 6){
+                  if (self.config.debug) {
+                    self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.Saturation) get failed polling Saturation, return value \n' + device.light[0]["5706"])
+                  }
+                  device.light[0]["5706"] = "ffcea6" //Default value when it fails polling
+                }
+                var hsl;
+                try {
+                  hsl = utils.convertRGBToHSL(device.light[0]["5706"])
+                } catch (error) {
+                  hsl = utils.convertRGBToHSL("ffcea6"); //default value
+                  if (self.config.debug) {          
+                    self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.Saturation) set convertRGBToHSL '  + device.light[0]["5706"]+  '\n' + error.message)
+                  }
+                }
+                callback(null, hsl[1] * 100)
+              })
+            } catch (error) {
+              if (self.config.debug) {
+                self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.Saturation) get \n' + error.message)
               }
-              var hsl = utils.convertRGBToHSL(device.light[0]["5706"]);
-              callback(null, hsl[1] * 100)
-            })
+              callback("no_response")
+            }
+
 
           })
           .on('set', (saturation, callback) => {
             self.color.saturation = saturation / 100
-            if (typeof self.color.hue !== 'undefined') {
-              utils.setColor(self.config, self.device.instanceId, self.color, result => callback())
-              self.color = {}
-            }else{
-              callback()            
+            try {
+              if (typeof self.color.hue !== 'undefined') {
+                utils.setColor(self.config, self.device.instanceId, self.color, result => callback())
+                self.color = {}
+              }else{
+                callback()            
+              }
+            } catch (error) {
+              if (self.config.debug) {
+                self.config.log('ERROR lightbulbService.getCharacteristic(Characteristic.Saturation) set \n' + error.message)
+              }
+              callback("no_response")
             }
           })
     }

--- a/utils.js
+++ b/utils.js
@@ -23,7 +23,13 @@ module.exports.setBrightness = (config, id, brightness, callback) => {
     config.log(cmd)
   }
 
-  callback(execSync(cmd, {encoding: "utf8"}))
+  let execSyncResult;
+  try {
+    execSyncResult = execSync(cmd, {encoding: "utf8", timeout: 3000})
+  } catch (error) {
+    execSyncResult = "no_response"
+  }
+  callback(execSyncResult)
 }
 
 module.exports.setKelvin = (config, id, kelvin, callback) => {
@@ -33,7 +39,13 @@ module.exports.setKelvin = (config, id, kelvin, callback) => {
   if (config.debug) {
     config.log(cmd)
   }
-  callback(execSync(cmd, {encoding: "utf8"}))
+  let execSyncResult;
+  try {
+    execSyncResult = execSync(cmd, {encoding: "utf8", timeout: 3000})
+  } catch (error) {
+    execSyncResult = "no_response"
+  }
+  callback(execSyncResult)
 }
   
 // Source: http://stackoverflow.com/a/9493060
@@ -127,7 +139,13 @@ module.exports.setColor = (config, id, color, callback) => {
   if (config.debug) {
     config.log(cmd)
   }
-  callback(execSync(cmd, {encoding: "utf8"}))
+  let execSyncResult;
+  try {
+    execSyncResult = execSync(cmd, {encoding: "utf8", timeout: 3000})
+  } catch (error) {
+    execSyncResult = "no_response"
+  }
+  callback(execSyncResult)
 }
 
 // @TODO: Figure out if the gateway actually don't support this
@@ -138,7 +156,13 @@ module.exports.setOnOff = (config, id, state, callback) => {
   if (config.debug) {
     config.log(cmd)
   }
-  callback(execSync(cmd, {encoding: "utf8"}))
+  let execSyncResult;
+  try {
+    execSyncResult = execSync(cmd, {encoding: "utf8", timeout: 3000})
+  } catch (error) {
+    execSyncResult = "no_response"
+  }
+  callback(execSyncResult)
 }
 
 const parseDeviceList = str => {
@@ -152,7 +176,7 @@ module.exports.getDevices = config => new Promise((resolve, reject) => {
     config.log(cmd)
   }
 
-  resolve(parseDeviceList(execSync(cmd, {encoding: "utf8"})))
+  resolve(parseDeviceList(execSync(cmd, {encoding: "utf8",timeout: 3000})))
 })
 
 const parseDevice = str => {
@@ -197,6 +221,12 @@ module.exports.getDevice = (config, id) => new Promise((resolve, reject) => {
     config.log(cmd)
   }
 
-  resolve(parseDevice(execSync(cmd, {encoding: "utf8"})))
+  let getDeviceResult
+  try {
+    getDeviceResult = execSync(cmd, {encoding: "utf8", timeout: 3000})
+    resolve(parseDevice(getDeviceResult))
+  } catch (error) {
+    resolve(null)
+  }
 
 })


### PR DESCRIPTION
- utils.js
-- Added timeout to execsync. Sometimes the call to coap-client just
   hangs indefinitely. Can be to a bulb gone missing or some other
   issues in the ikea gateway.
- index.js
-- Try catch wrappers on lots of calls. When an error is trapped, just
   do a callback("no_response") instead of failing (and breaking the
   entire homebridge). This way it recovers in subsequent updates
   from Homekit.

TODO:
Sometimes the bulbs start att 100% when turned on (even if that wasn't
the setting). This can be on these checks

```
if(typeof device.light[0]["5706"] === 'undefined' ||
  device.light[0]["5706"] && device.light[0]["5706"].length < 6){
```

I change from !== 'undefined' to === that seemed more as the intention.
Logging says return value in this cases is always 0, maybe that is a
correct value?